### PR TITLE
feat: build calendar spa frontend

### DIFF
--- a/backend/app/routes/user_route.py
+++ b/backend/app/routes/user_route.py
@@ -46,7 +46,8 @@ async def google_callback(code: str, db: AsyncSession = Depends(get_db)):
         jwt_access_token = create_access_token(data={"sub": user.user_id})
 
         # 프론트엔드로 리디렉션
-        redirect_url = f"{FRONTEND_URL}/auth/callback?access_token={jwt_access_token}"
+        redirect_base = FRONTEND_URL.rstrip("/")
+        redirect_url = f"{redirect_base}/auth/callback?access_token={jwt_access_token}"
         return RedirectResponse(url=redirect_url)
 
     except HTTPException:

--- a/backend/app/variable.py
+++ b/backend/app/variable.py
@@ -1,8 +1,55 @@
 import os
 from dotenv import load_dotenv
+from urllib.parse import urlparse, urlunparse
 
 
 load_dotenv()
+
+_ALLOWED_FRONTEND_SCHEMES = {"http", "https"}
+
+
+def _normalize_frontend_url(url: str) -> str:
+    if not url:
+        return url
+
+    stripped = url.strip()
+
+    if not stripped:
+        return stripped
+
+    def _rebuild(parsed_url, default_scheme: str = "http") -> str:
+        scheme = parsed_url.scheme.lower() if parsed_url.scheme else default_scheme
+        netloc = parsed_url.netloc
+        path = parsed_url.path
+
+        if not netloc and path:
+            segments = path.split("/", 1)
+            netloc = segments[0]
+            path = f"/{segments[1]}" if len(segments) == 2 else ""
+
+        return urlunparse((scheme, netloc, path, "", "", ""))
+
+    if stripped.startswith("//"):
+        parsed = urlparse(f"http:{stripped}")
+        return _rebuild(parsed)
+
+    if "://" not in stripped:
+        parsed = urlparse(f"http://{stripped}")
+        return _rebuild(parsed)
+
+    parsed = urlparse(stripped)
+
+    if (
+        parsed.scheme
+        and parsed.netloc
+        and parsed.scheme.lower() in _ALLOWED_FRONTEND_SCHEMES
+    ):
+        return _rebuild(parsed, parsed.scheme.lower())
+
+    remainder = stripped.split("://", 1)[1]
+    parsed = urlparse(f"http://{remainder}")
+
+    return _rebuild(parsed)
 
 
 SQLALCHEMY_DATABASE_URL_USER = os.environ.get("SQLALCHEMY_DATABASE_URL_USER")
@@ -21,4 +68,6 @@ GOOGLE_FORCE_PROMPT_CONSENT = (
     os.getenv("GOOGLE_FORCE_PROMPT_CONSENT", "false").lower() == "true"
 )
 
-FRONTEND_URL = os.getenv("FRONTEND_URL", "localhost:5173")
+FRONTEND_URL = _normalize_frontend_url(
+    os.getenv("FRONTEND_URL", "http://localhost:5173")
+)

--- a/backend/tests/test_variable.py
+++ b/backend/tests/test_variable.py
@@ -3,19 +3,84 @@ import sys
 from pathlib import Path
 
 
-def test_frontend_url_default(monkeypatch):
-    root_dir = Path(__file__).resolve().parents[1]
-    sys.path.insert(0, str(root_dir))
-    monkeypatch.delenv("FRONTEND_URL", raising=False)
-    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
-    monkeypatch.setenv("REFRESH_TOKEN_EXPIRE_MINUTES", "120")
-    monkeypatch.setenv("SECRET_KEY", "test")
-    monkeypatch.setenv("ALGORITHM", "HS256")
-    monkeypatch.setenv("SQLALCHEMY_DATABASE_URL_USER", "sqlite+aiosqlite:///:memory:")
-    monkeypatch.setenv("GOOGLE_CLIENT_ID", "client")
-    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "secret")
-    monkeypatch.setenv("GOOGLE_REDIRECT_URI", "http://localhost")
-    module = importlib.import_module("app.variable")
-    reloaded = importlib.reload(module)
+_ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(_ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(_ROOT_DIR))
 
-    assert reloaded.FRONTEND_URL == "localhost:5173"
+
+_COMMON_ENV = {
+    "ACCESS_TOKEN_EXPIRE_MINUTES": "60",
+    "REFRESH_TOKEN_EXPIRE_MINUTES": "120",
+    "SECRET_KEY": "test",
+    "ALGORITHM": "HS256",
+    "SQLALCHEMY_DATABASE_URL_USER": "sqlite+aiosqlite:///:memory:",
+    "GOOGLE_CLIENT_ID": "client",
+    "GOOGLE_CLIENT_SECRET": "secret",
+    "GOOGLE_REDIRECT_URI": "http://localhost",
+}
+
+_UNSET = object()
+
+
+def _reload_variable(monkeypatch, frontend_url=_UNSET):
+    for key, value in _COMMON_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    if frontend_url is _UNSET:
+        monkeypatch.delenv("FRONTEND_URL", raising=False)
+    elif frontend_url is None:
+        monkeypatch.delenv("FRONTEND_URL", raising=False)
+    else:
+        monkeypatch.setenv("FRONTEND_URL", frontend_url)
+
+    module = importlib.import_module("app.variable")
+
+    return importlib.reload(module)
+
+
+def test_frontend_url_default(monkeypatch):
+    reloaded = _reload_variable(monkeypatch)
+
+    assert reloaded.FRONTEND_URL == "http://localhost:5173"
+
+
+def test_frontend_url_without_scheme(monkeypatch):
+    reloaded = _reload_variable(monkeypatch, "example.com")
+
+    assert reloaded.FRONTEND_URL == "http://example.com"
+
+
+def test_frontend_url_without_scheme_but_with_port(monkeypatch):
+    reloaded = _reload_variable(monkeypatch, "localhost:5173")
+
+    assert reloaded.FRONTEND_URL == "http://localhost:5173"
+
+
+def test_frontend_url_with_path(monkeypatch):
+    reloaded = _reload_variable(monkeypatch, "example.com/app")
+
+    assert reloaded.FRONTEND_URL == "http://example.com/app"
+
+
+def test_frontend_url_strips_whitespace(monkeypatch):
+    reloaded = _reload_variable(monkeypatch, "  example.com \n")
+
+    assert reloaded.FRONTEND_URL == "http://example.com"
+
+
+def test_frontend_url_preserves_valid_scheme(monkeypatch):
+    reloaded = _reload_variable(monkeypatch, "https://app.example.com")
+
+    assert reloaded.FRONTEND_URL == "https://app.example.com"
+
+
+def test_frontend_url_handles_network_path_reference(monkeypatch):
+    reloaded = _reload_variable(monkeypatch, "//localhost:5173")
+
+    assert reloaded.FRONTEND_URL == "http://localhost:5173"
+
+
+def test_frontend_url_ignores_unknown_scheme(monkeypatch):
+    reloaded = _reload_variable(monkeypatch, "custom://localhost:5173")
+
+    assert reloaded.FRONTEND_URL == "http://localhost:5173"

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_BASE_URL=http://localhost:7777
 VITE_FRONTEND_URL=http://localhost:5173

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=http://localhost:8000
+VITE_FRONTEND_URL=http://localhost:5173

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -252,6 +252,7 @@ obj/
 # Mobile Tools for Java (J2ME)
 
 # Package Files #
+package-lock.json
 
 # virtual machine crash logs (Reference: http://www.java.com/en/download/help/error_hotspot.xml)
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,33 @@
-# Frontend
+# Yakssok Frontend
 
-프론트엔드(웹 및 모바일)은 이곳에 프로젝트를 생성합니다.
+Google OAuth와 Google Calendar 연동 흐름을 확인할 수 있는 React + Vite + TypeScript 기반 SPA입니다.
+
+## 주요 기능
+
+- Google OAuth 로그인 / 재인증 흐름
+- JWT 로컬 저장 및 Axios 인터셉터를 통한 자동 인증 헤더 주입
+- 주간 / 월간 캘린더 뷰와 기간 이동
+- Google 권한 만료 시 재인증 안내 배너
+- Tailwind CSS를 활용한 아이보리 톤 UI
+
+## 환경 변수
+
+`.env` 파일을 생성하여 아래 값을 설정하세요.
+
+```bash
+VITE_API_BASE_URL=http://localhost:8000
+VITE_FRONTEND_URL=http://localhost:5173
+```
+
+## 개발 서버 실행
+
+```bash
+npm install
+npm run dev
+```
+
+## 프로덕션 빌드
+
+```bash
+npm run build
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Yakssok Calendar</title>
+  </head>
+  <body class="bg-ivory text-ink">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "yakssok-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.7.2",
+    "classnames": "^2.5.1",
+    "date-fns": "^3.6.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.23",
+    "@vitejs/plugin-react": "^4.2.1",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.8"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,12 @@
+import { Outlet } from 'react-router-dom';
+import Layout from './components/Layout/Layout';
+
+const App = () => {
+  return (
+    <Layout>
+      <Outlet />
+    </Layout>
+  );
+};
+
+export default App;

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,10 @@
+import { apiClient } from './client';
+
+interface LoginResponse {
+  auth_url: string;
+}
+
+export const requestGoogleLogin = async (force = false) => {
+  const response = await apiClient.get<LoginResponse>(`/user/google/login${force ? '?force=1' : ''}`);
+  return response.data;
+};

--- a/frontend/src/api/calendar.ts
+++ b/frontend/src/api/calendar.ts
@@ -1,0 +1,35 @@
+import { apiClient } from './client';
+import { CalendarEvent, CalendarEventResponse } from '../types';
+
+interface FetchCalendarParams {
+  timeMin: string;
+  timeMax: string;
+  maxResults?: number;
+}
+
+export const fetchCalendarEvents = async (
+  params: FetchCalendarParams & { pageToken?: string },
+): Promise<CalendarEventResponse> => {
+  const response = await apiClient.get<CalendarEventResponse>('/calendar/events', {
+    params: {
+      time_min: params.timeMin,
+      time_max: params.timeMax,
+      max_results: params.maxResults ?? 50,
+      page_token: params.pageToken,
+    },
+  });
+  return response.data;
+};
+
+export const fetchAllCalendarEvents = async (params: FetchCalendarParams): Promise<CalendarEvent[]> => {
+  const events: CalendarEvent[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const response = await fetchCalendarEvents({ ...params, pageToken });
+    events.push(...response.events);
+    pageToken = response.nextPageToken;
+  } while (pageToken);
+
+  return events;
+};

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+const API_BASE_URL = 'http://localhost:7777'
 
 export interface ReauthPayload {
   visible: boolean;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,77 @@
+import axios from 'axios';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+
+export interface ReauthPayload {
+  visible: boolean;
+  code?: string;
+  message?: string;
+  reauthUrl?: string;
+}
+
+interface ConfigureClientOptions {
+  getToken?: () => string;
+  onUnauthorized?: () => void;
+  onReauthRequired?: (payload: ReauthPayload) => void;
+}
+
+const reauthCodes = new Set([
+  'google_reauth_required',
+  'calendar_scope_missing',
+  'insufficient_scope',
+]);
+
+const defaultHandlers = {
+  getToken: () => '',
+  onUnauthorized: () => {},
+  onReauthRequired: (_payload: ReauthPayload) => {},
+};
+
+const handlers = { ...defaultHandlers };
+
+export const configureClient = ({ getToken, onUnauthorized, onReauthRequired }: ConfigureClientOptions) => {
+  if (getToken) handlers.getToken = getToken;
+  if (onUnauthorized) handlers.onUnauthorized = onUnauthorized;
+  if (onReauthRequired) handlers.onReauthRequired = onReauthRequired;
+};
+
+export const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+});
+
+apiClient.interceptors.request.use((config) => {
+  const token = handlers.getToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (axios.isAxiosError(error) && error.response) {
+      const { status, data } = error.response;
+      const code: string | undefined = data?.code;
+      if (code && reauthCodes.has(code)) {
+        const messageMap: Record<string, string> = {
+          google_reauth_required: 'Google 인증 세션이 만료되었습니다. 다시 연결해주세요.',
+          calendar_scope_missing: '캘린더 접근 권한이 부족합니다. 다시 연결해주세요.',
+          insufficient_scope: '요청한 범위 권한이 없습니다. 권한을 다시 부여해주세요.',
+        };
+        handlers.onReauthRequired({
+          visible: true,
+          code,
+          message: data?.message ?? messageMap[code] ?? 'Google 권한을 다시 연결해주세요.',
+          reauthUrl: data?.reauthUrl,
+        });
+        return Promise.reject(error);
+      }
+
+      if (status === 401) {
+        handlers.onUnauthorized();
+      }
+    }
+    return Promise.reject(error);
+  },
+);

--- a/frontend/src/components/Calendar/EventItem.tsx
+++ b/frontend/src/components/Calendar/EventItem.tsx
@@ -1,6 +1,7 @@
 import { format } from 'date-fns';
 import { CalendarEvent } from '../../types';
 import { getEventColorClass } from '../../utils/colors';
+import { toValidDate } from '../../utils/dates';
 
 interface EventItemProps {
   event: CalendarEvent;
@@ -10,9 +11,9 @@ interface EventItemProps {
 }
 
 const EventItem = ({ event, className, style, showTime = true }: EventItemProps) => {
-  const startDate = new Date(event.start);
-  const endDate = new Date(event.end);
-  const timeLabel = `${format(startDate, 'HH:mm')} - ${format(endDate, 'HH:mm')}`;
+  const startDate = toValidDate(event.start);
+  const endDate = toValidDate(event.end);
+  const timeLabel = startDate && endDate ? `${format(startDate, 'HH:mm')} - ${format(endDate, 'HH:mm')}` : null;
   const colorClass = getEventColorClass(event.summary);
 
   return (
@@ -21,7 +22,7 @@ const EventItem = ({ event, className, style, showTime = true }: EventItemProps)
       style={style}
     >
       <div className="font-semibold">{event.summary || '제목 없음'}</div>
-      {showTime && <div className="text-[10px] text-ink/80">{timeLabel}</div>}
+      {showTime && timeLabel && <div className="text-[10px] text-ink/80">{timeLabel}</div>}
       {event.location && <div className="mt-0.5 text-[10px] text-ink/60">{event.location}</div>}
     </div>
   );

--- a/frontend/src/components/Calendar/EventItem.tsx
+++ b/frontend/src/components/Calendar/EventItem.tsx
@@ -1,0 +1,30 @@
+import { format } from 'date-fns';
+import { CalendarEvent } from '../../types';
+import { getEventColorClass } from '../../utils/colors';
+
+interface EventItemProps {
+  event: CalendarEvent;
+  className?: string;
+  style?: React.CSSProperties;
+  showTime?: boolean;
+}
+
+const EventItem = ({ event, className, style, showTime = true }: EventItemProps) => {
+  const startDate = new Date(event.start);
+  const endDate = new Date(event.end);
+  const timeLabel = `${format(startDate, 'HH:mm')} - ${format(endDate, 'HH:mm')}`;
+  const colorClass = getEventColorClass(event.summary);
+
+  return (
+    <div
+      className={`group relative rounded-md border border-white/70 px-2 py-1 text-xs text-ink shadow-sm transition hover:shadow-md ${colorClass} ${className ?? ''}`.trim()}
+      style={style}
+    >
+      <div className="font-semibold">{event.summary || '제목 없음'}</div>
+      {showTime && <div className="text-[10px] text-ink/80">{timeLabel}</div>}
+      {event.location && <div className="mt-0.5 text-[10px] text-ink/60">{event.location}</div>}
+    </div>
+  );
+};
+
+export default EventItem;

--- a/frontend/src/components/Calendar/MonthlyGrid.tsx
+++ b/frontend/src/components/Calendar/MonthlyGrid.tsx
@@ -1,7 +1,7 @@
 import { format } from 'date-fns';
 import classNames from 'classnames';
 import { CalendarEvent } from '../../types';
-import { getMonthMatrix, isDateInCurrentMonth } from '../../utils/dates';
+import { getMonthMatrix, isDateInCurrentMonth, toValidDate } from '../../utils/dates';
 import { getEventColorClass } from '../../utils/colors';
 
 interface MonthlyGridProps {
@@ -12,7 +12,12 @@ interface MonthlyGridProps {
 const MonthlyGrid = ({ events, current }: MonthlyGridProps) => {
   const matrix = getMonthMatrix(current);
   const eventsByDate = events.reduce<Record<string, CalendarEvent[]>>((acc, event) => {
-    const dateKey = format(new Date(event.start), 'yyyy-MM-dd');
+    const eventDate = toValidDate(event.start);
+    if (!eventDate) {
+      return acc;
+    }
+
+    const dateKey = format(eventDate, 'yyyy-MM-dd');
     if (!acc[dateKey]) {
       acc[dateKey] = [];
     }

--- a/frontend/src/components/Calendar/MonthlyGrid.tsx
+++ b/frontend/src/components/Calendar/MonthlyGrid.tsx
@@ -1,0 +1,59 @@
+import { format } from 'date-fns';
+import classNames from 'classnames';
+import { CalendarEvent } from '../../types';
+import { getMonthMatrix, isDateInCurrentMonth } from '../../utils/dates';
+import { getEventColorClass } from '../../utils/colors';
+
+interface MonthlyGridProps {
+  events: CalendarEvent[];
+  current: Date;
+}
+
+const MonthlyGrid = ({ events, current }: MonthlyGridProps) => {
+  const matrix = getMonthMatrix(current);
+  const eventsByDate = events.reduce<Record<string, CalendarEvent[]>>((acc, event) => {
+    const dateKey = format(new Date(event.start), 'yyyy-MM-dd');
+    if (!acc[dateKey]) {
+      acc[dateKey] = [];
+    }
+    acc[dateKey].push(event);
+    return acc;
+  }, {});
+
+  return (
+    <div className="grid flex-1 grid-cols-7 border border-border/80 bg-white/40 text-sm">
+      {matrix.flat().map((day) => {
+        const dateKey = format(day, 'yyyy-MM-dd');
+        const dayEvents = eventsByDate[dateKey] ?? [];
+        const visibleEvents = dayEvents.slice(0, 3);
+        const hiddenCount = Math.max(0, dayEvents.length - visibleEvents.length);
+        return (
+          <div
+            key={dateKey}
+            className={classNames(
+              'flex h-32 flex-col border-r border-b border-border/60 p-2 transition hover:bg-positive/10',
+              !isDateInCurrentMonth(day, current) && 'bg-ivory/80 text-ink/40',
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold">{format(day, 'd')}</span>
+            </div>
+            <div className="mt-2 space-y-1 text-[11px]">
+              {visibleEvents.map((event) => (
+                <div key={event.id} className="flex items-center gap-2">
+                  <span className={`h-2 w-2 rounded-full ${getEventColorClass(event.summary)}`} />
+                  <span className="truncate">{event.summary}</span>
+                </div>
+              ))}
+              {hiddenCount > 0 && (
+                <div className="text-xs text-ink/60">+{hiddenCount} more</div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MonthlyGrid;

--- a/frontend/src/components/Calendar/WeeklyGrid.tsx
+++ b/frontend/src/components/Calendar/WeeklyGrid.tsx
@@ -7,7 +7,7 @@ import {
   setSeconds,
 } from 'date-fns';
 import { CalendarEvent } from '../../types';
-import { getWeekDays } from '../../utils/dates';
+import { getWeekDays, toValidDate } from '../../utils/dates';
 import EventItem from './EventItem';
 
 interface WeeklyGridProps {
@@ -44,8 +44,11 @@ const getPositionedEvents = (events: CalendarEvent[], day: Date): PositionedEven
 
   const filtered = events
     .map((event) => {
-      const rawStart = new Date(event.start);
-      const rawEnd = new Date(event.end);
+      const rawStart = toValidDate(event.start);
+      const rawEnd = toValidDate(event.end);
+      if (!rawStart || !rawEnd) {
+        return null;
+      }
       const start = clampToDayRange(rawStart, day);
       const end = clampToDayRange(rawEnd, day);
       if (end <= dayStart || start >= dayEnd) {
@@ -145,8 +148,12 @@ const WeeklyGrid = ({ events, start }: WeeklyGridProps) => {
           <div className="absolute inset-0 grid grid-cols-7">
             {days.map((day) => {
               const dayEvents = events.filter((event) => {
-                const eventStart = new Date(event.start);
-                const eventEnd = new Date(event.end);
+                const eventStart = toValidDate(event.start);
+                const eventEnd = toValidDate(event.end);
+                if (!eventStart || !eventEnd) {
+                  return false;
+                }
+
                 return eventEnd > day && eventStart < addHours(day, 24);
               });
               const positioned = getPositionedEvents(dayEvents, day);

--- a/frontend/src/components/Calendar/WeeklyGrid.tsx
+++ b/frontend/src/components/Calendar/WeeklyGrid.tsx
@@ -1,0 +1,181 @@
+import {
+  addHours,
+  differenceInMinutes,
+  format,
+  setHours,
+  setMinutes,
+  setSeconds,
+} from 'date-fns';
+import { CalendarEvent } from '../../types';
+import { getWeekDays } from '../../utils/dates';
+import EventItem from './EventItem';
+
+interface WeeklyGridProps {
+  events: CalendarEvent[];
+  start: Date;
+}
+
+interface PositionedEvent {
+  event: CalendarEvent;
+  top: number;
+  height: number;
+  left: string;
+  width: string;
+}
+
+const START_HOUR = 8;
+const END_HOUR = 22;
+const PIXELS_PER_MINUTE = 64 / 60;
+
+const resetToDayStart = (date: Date) => {
+  return setSeconds(setMinutes(setHours(date, START_HOUR), 0), 0);
+};
+
+const clampToDayRange = (date: Date, day: Date) => {
+  const dayStart = resetToDayStart(day);
+  const dayEnd = setSeconds(setMinutes(setHours(day, END_HOUR), 0), 0);
+  const start = date < dayStart ? dayStart : date;
+  return start > dayEnd ? dayEnd : start;
+};
+
+const getPositionedEvents = (events: CalendarEvent[], day: Date): PositionedEvent[] => {
+  const dayStart = resetToDayStart(day);
+  const dayEnd = setSeconds(setMinutes(setHours(day, END_HOUR), 0), 0);
+
+  const filtered = events
+    .map((event) => {
+      const rawStart = new Date(event.start);
+      const rawEnd = new Date(event.end);
+      const start = clampToDayRange(rawStart, day);
+      const end = clampToDayRange(rawEnd, day);
+      if (end <= dayStart || start >= dayEnd) {
+        return null;
+      }
+      return {
+        event,
+        start,
+        end,
+        startMinutes: Math.max(0, differenceInMinutes(start, dayStart)),
+        endMinutes: Math.max(0, differenceInMinutes(end, dayStart)),
+      };
+    })
+    .filter((value): value is {
+      event: CalendarEvent;
+      start: Date;
+      end: Date;
+      startMinutes: number;
+      endMinutes: number;
+    } => Boolean(value))
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+  const positioned: PositionedEvent[] = [];
+  const active: Array<{ startMinutes: number; endMinutes: number; col: number; node: PositionedEvent }> = [];
+
+  const updateActiveWidths = () => {
+    if (active.length === 0) {
+      return;
+    }
+    const maxCol = Math.max(...active.map((item) => item.col)) + 1;
+    const width = 100 / maxCol;
+    active.forEach((activeItem) => {
+      activeItem.node.width = `calc(${width}% - 6px)`;
+      activeItem.node.left = `calc(${(100 / maxCol) * activeItem.col}% + ${activeItem.col * 4}px)`;
+    });
+  };
+
+  filtered.forEach((item) => {
+    const { startMinutes, endMinutes } = item;
+    for (let i = active.length - 1; i >= 0; i -= 1) {
+      if (active[i].endMinutes <= startMinutes) {
+        active.splice(i, 1);
+      }
+    }
+    updateActiveWidths();
+
+    const usedColumns = new Set(active.map((a) => a.col));
+    let col = 0;
+    while (usedColumns.has(col)) {
+      col += 1;
+    }
+
+    const top = startMinutes * PIXELS_PER_MINUTE;
+    const height = Math.max(36, (endMinutes - startMinutes) * PIXELS_PER_MINUTE);
+    const position: PositionedEvent = {
+      event: item.event,
+      top,
+      height,
+      left: '0%',
+      width: '100%',
+    };
+
+    const node = { startMinutes, endMinutes, col, node: position };
+    active.push(node);
+    updateActiveWidths();
+
+    positioned.push(position);
+  });
+
+  return positioned;
+};
+
+const WeeklyGrid = ({ events, start }: WeeklyGridProps) => {
+  const days = getWeekDays(start);
+  const hours = Array.from({ length: END_HOUR - START_HOUR + 1 }, (_, index) => START_HOUR + index);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="grid grid-cols-8 border-b border-border/80 bg-white/60 text-sm text-ink">
+        <div className="px-2 py-3 text-right text-xs text-ink/60">시간</div>
+        {days.map((day) => (
+          <div key={day.toISOString()} className="px-2 py-3 text-center">
+            <div className="text-xs text-ink/60">{format(day, 'EEE')}</div>
+            <div className="text-base font-semibold">{format(day, 'd')}</div>
+          </div>
+        ))}
+      </div>
+      <div className="flex flex-1 overflow-hidden">
+        <div className="relative w-16 border-r border-border/80 bg-white/40 text-right text-xs text-ink/60">
+          {hours.map((hour) => (
+            <div key={hour} className="h-16 border-b border-border/60 pr-2">
+              <span className="relative -top-2 inline-block">{`${hour.toString().padStart(2, '0')}:00`}</span>
+            </div>
+          ))}
+        </div>
+        <div className="relative flex-1">
+          <div className="absolute inset-0 grid grid-cols-7">
+            {days.map((day) => {
+              const dayEvents = events.filter((event) => {
+                const eventStart = new Date(event.start);
+                const eventEnd = new Date(event.end);
+                return eventEnd > day && eventStart < addHours(day, 24);
+              });
+              const positioned = getPositionedEvents(dayEvents, day);
+              return (
+                <div key={day.toISOString()} className="relative border-r border-border/60 last:border-r-0">
+                  {hours.map((hour) => (
+                    <div key={hour} className="h-16 border-b border-border/40" />
+                  ))}
+                  {positioned.map((item) => (
+                    <EventItem
+                      key={`${item.event.id}-${item.top}`}
+                      event={item.event}
+                      style={{
+                        position: 'absolute',
+                        top: item.top,
+                        height: item.height,
+                        left: item.left,
+                        width: item.width,
+                      }}
+                    />
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WeeklyGrid;

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,0 +1,125 @@
+import { ReactNode, createContext, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { requestGoogleLogin } from '../../api/auth';
+import { useAuth } from '../../hooks/useAuth';
+import ReauthBanner from './ReauthBanner';
+import Sidebar from './Sidebar';
+import TopBar from './TopBar';
+
+export type ViewType = 'weekly' | 'monthly';
+
+export interface HeaderConfig {
+  periodLabel: string;
+  onPrev?: () => void;
+  onNext?: () => void;
+  onToday?: () => void;
+  viewType: ViewType;
+  onViewChange?: (view: ViewType) => void;
+}
+
+interface LayoutContextValue {
+  setHeaderConfig: (config: Partial<HeaderConfig>) => void;
+}
+
+export const LayoutConfigContext = createContext<LayoutContextValue>({
+  setHeaderConfig: () => {},
+});
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const defaultHeader: HeaderConfig = {
+  periodLabel: '',
+  viewType: 'weekly',
+};
+
+const infoPanelContent = [
+  '1) 사용자가 "Google로 로그인" 버튼을 클릭합니다.',
+  '2) 백엔드가 Google OAuth 동의 화면 URL을 반환하고, 사용자는 해당 URL로 이동합니다.',
+  '3) 동의를 완료하면 백엔드가 JWT를 발급하고 프런트엔드 콜백 URL로 토큰을 전달합니다.',
+  '4) 프런트엔드는 토큰을 저장하고 모든 캘린더 API 호출에 Authorization 헤더를 포함합니다.',
+];
+
+const Layout = ({ children }: LayoutProps) => {
+  const location = useLocation();
+  const { logout, reauthInfo, dismissReauth } = useAuth();
+  const [headerConfig, setHeaderConfig] = useState<HeaderConfig>(defaultHeader);
+  const [infoOpen, setInfoOpen] = useState(false);
+  const [reauthLoading, setReauthLoading] = useState(false);
+
+  const handleReauth = async () => {
+    try {
+      setReauthLoading(true);
+      const { auth_url: authUrl } = await requestGoogleLogin(true);
+      window.location.assign(authUrl);
+    } catch (error) {
+      console.error(error);
+      alert('재인증 링크를 가져오지 못했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setReauthLoading(false);
+    }
+  };
+
+  const contextValue = useMemo(
+    () => ({
+      setHeaderConfig: (config: Partial<HeaderConfig>) => {
+        setHeaderConfig((prev) => ({ ...prev, ...config }));
+      },
+    }),
+    [],
+  );
+
+  return (
+    <LayoutConfigContext.Provider value={contextValue}>
+      <div className="flex h-screen bg-ivory">
+        <Sidebar currentPath={location.pathname} onToggleInfo={() => setInfoOpen((prev) => !prev)} />
+        <div className="relative flex flex-1 flex-col">
+          <ReauthBanner
+            visible={Boolean(reauthInfo?.visible)}
+            message={reauthInfo?.message}
+            loading={reauthLoading}
+            onClose={dismissReauth}
+            onReauth={handleReauth}
+          />
+          <TopBar
+            periodLabel={headerConfig.periodLabel}
+            onPrev={headerConfig.onPrev}
+            onNext={headerConfig.onNext}
+            onToday={headerConfig.onToday}
+            viewType={headerConfig.viewType}
+            onViewChange={headerConfig.onViewChange}
+            onToggleInfo={() => setInfoOpen((prev) => !prev)}
+            onLogout={logout}
+          />
+          <div className="relative flex flex-1 overflow-hidden">
+            <main className="flex-1 overflow-y-auto p-6 pr-4">{children}</main>
+            <aside
+              className={`absolute right-0 top-0 h-full w-72 transform bg-white/90 p-6 shadow-lg transition-transform duration-300 ease-in-out ${infoOpen ? 'translate-x-0' : 'translate-x-full'}`}
+              aria-hidden={!infoOpen}
+            >
+              <h2 className="text-lg font-semibold text-ink">OAuth 흐름 안내</h2>
+              <ol className="mt-4 space-y-3 text-sm text-ink/70">
+                {infoPanelContent.map((item) => (
+                  <li key={item} className="flex gap-2">
+                    <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-positive" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ol>
+              <button
+                type="button"
+                className="mt-6 w-full rounded-md border border-border px-4 py-2 text-sm text-ink transition hover:border-positive hover:text-positive"
+                onClick={() => setInfoOpen(false)}
+              >
+                닫기
+              </button>
+            </aside>
+          </div>
+        </div>
+      </div>
+    </LayoutConfigContext.Provider>
+  );
+};
+
+export default Layout;

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -15,6 +15,8 @@ export interface HeaderConfig {
   onToday?: () => void;
   viewType: ViewType;
   onViewChange?: (view: ViewType) => void;
+  onRefresh?: () => void | Promise<void>;
+  isRefreshing?: boolean;
 }
 
 interface LayoutContextValue {
@@ -32,6 +34,7 @@ interface LayoutProps {
 const defaultHeader: HeaderConfig = {
   periodLabel: '',
   viewType: 'weekly',
+  isRefreshing: false,
 };
 
 const infoPanelContent = [
@@ -89,6 +92,8 @@ const Layout = ({ children }: LayoutProps) => {
             onToday={headerConfig.onToday}
             viewType={headerConfig.viewType}
             onViewChange={headerConfig.onViewChange}
+            onRefresh={headerConfig.onRefresh}
+            isRefreshing={headerConfig.isRefreshing}
             onToggleInfo={() => setInfoOpen((prev) => !prev)}
             onLogout={logout}
           />

--- a/frontend/src/components/Layout/ReauthBanner.tsx
+++ b/frontend/src/components/Layout/ReauthBanner.tsx
@@ -1,0 +1,38 @@
+interface ReauthBannerProps {
+  visible: boolean;
+  message?: string;
+  loading?: boolean;
+  onReauth: () => void;
+  onClose: () => void;
+}
+
+const ReauthBanner = ({ visible, message, loading, onReauth, onClose }: ReauthBannerProps) => {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-between border-b border-warning/40 bg-warning/30 px-6 py-2 text-sm text-ink">
+      <div>{message ?? 'Google 권한이 만료되었습니다. 다시 연결해주세요.'}</div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="rounded-md border border-warning px-3 py-1 text-sm font-medium text-ink transition hover:bg-warning/40"
+          onClick={onReauth}
+          disabled={loading}
+        >
+          {loading ? '연결 중...' : 'Google 권한 다시 연결'}
+        </button>
+        <button
+          type="button"
+          className="rounded-md border border-border px-2 py-1 text-xs text-ink/60 transition hover:text-ink"
+          onClick={onClose}
+        >
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ReauthBanner;

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -1,0 +1,57 @@
+import { NavLink } from 'react-router-dom';
+import classNames from 'classnames';
+
+interface SidebarProps {
+  currentPath: string;
+  onToggleInfo: () => void;
+}
+
+const menuItems = [
+  { to: '/home/weekly', label: '주간' },
+  { to: '/home/monthly', label: '월간' },
+];
+
+const Sidebar = ({ currentPath, onToggleInfo }: SidebarProps) => {
+  return (
+    <aside className="flex w-16 flex-col items-center bg-white/70 py-6 shadow-sm backdrop-blur">
+      <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-border">
+        <div className="grid grid-cols-3 gap-0.5">
+          {Array.from({ length: 9 }).map((_, index) => (
+            <span key={index} className="h-1.5 w-1.5 rounded-full bg-positive" />
+          ))}
+        </div>
+      </div>
+      <nav className="mt-8 flex flex-1 flex-col items-center gap-4">
+        {menuItems.map((item) => {
+          const isActive = currentPath.startsWith(item.to);
+          return (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={classNames(
+                'flex h-10 w-10 items-center justify-center rounded-full text-xs font-medium transition',
+                isActive
+                  ? 'bg-positive/80 text-white'
+                  : 'text-ink/60 hover:bg-positive/20 hover:text-ink',
+              )}
+            >
+              {item.label.substring(0, 2)}
+            </NavLink>
+          );
+        })}
+      </nav>
+      <div className="mt-auto flex flex-col items-center gap-3">
+        <button
+          type="button"
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-border text-[11px] text-ink/60 transition hover:border-positive hover:text-positive"
+          onClick={onToggleInfo}
+        >
+          Info
+        </button>
+        <span className="text-[10px] text-ink/40">v1.0</span>
+      </div>
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/components/Layout/TopBar.tsx
+++ b/frontend/src/components/Layout/TopBar.tsx
@@ -8,6 +8,8 @@ interface TopBarProps {
   onToday?: () => void;
   viewType: ViewType;
   onViewChange?: (view: ViewType) => void;
+  onRefresh?: () => void | Promise<void>;
+  isRefreshing?: boolean;
   onToggleInfo: () => void;
   onLogout: () => void;
 }
@@ -19,6 +21,8 @@ const TopBar = ({
   onToday,
   viewType,
   onViewChange,
+  onRefresh,
+  isRefreshing,
   onToggleInfo,
   onLogout,
 }: TopBarProps) => {
@@ -53,6 +57,19 @@ const TopBar = ({
       </div>
       <div className="text-lg font-semibold text-ink">{periodLabel}</div>
       <div className="flex items-center gap-3">
+        {onRefresh && (
+          <button
+            type="button"
+            className="rounded-md border border-border px-3 py-1 text-sm text-ink transition hover:border-positive hover:text-positive disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={() => {
+              void onRefresh();
+            }}
+            disabled={Boolean(isRefreshing)}
+            aria-busy={Boolean(isRefreshing)}
+          >
+            {isRefreshing ? '동기화 중...' : '새로고침'}
+          </button>
+        )}
         <div className="flex rounded-full border border-border bg-white/70 p-1">
           {views.map((view) => (
             <button

--- a/frontend/src/components/Layout/TopBar.tsx
+++ b/frontend/src/components/Layout/TopBar.tsx
@@ -1,0 +1,93 @@
+import classNames from 'classnames';
+import { ViewType } from './Layout';
+
+interface TopBarProps {
+  periodLabel: string;
+  onPrev?: () => void;
+  onNext?: () => void;
+  onToday?: () => void;
+  viewType: ViewType;
+  onViewChange?: (view: ViewType) => void;
+  onToggleInfo: () => void;
+  onLogout: () => void;
+}
+
+const TopBar = ({
+  periodLabel,
+  onPrev,
+  onNext,
+  onToday,
+  viewType,
+  onViewChange,
+  onToggleInfo,
+  onLogout,
+}: TopBarProps) => {
+  const views: ViewType[] = ['weekly', 'monthly'];
+
+  return (
+    <header className="flex h-14 items-center justify-between border-b border-border/80 bg-white/70 px-6 backdrop-blur">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="rounded-md border border-border px-3 py-1 text-sm font-medium text-ink transition hover:border-positive hover:text-positive"
+          onClick={() => onToday?.()}
+        >
+          Today
+        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="rounded-md border border-border px-2 py-1 text-sm transition hover:border-positive hover:text-positive"
+            onClick={() => onPrev?.()}
+          >
+            ◀
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-border px-2 py-1 text-sm transition hover:border-positive hover:text-positive"
+            onClick={() => onNext?.()}
+          >
+            ▶
+          </button>
+        </div>
+      </div>
+      <div className="text-lg font-semibold text-ink">{periodLabel}</div>
+      <div className="flex items-center gap-3">
+        <div className="flex rounded-full border border-border bg-white/70 p-1">
+          {views.map((view) => (
+            <button
+              key={view}
+              type="button"
+              className={classNames(
+                'rounded-full px-3 py-1 text-sm capitalize transition',
+                viewType === view
+                  ? 'bg-positive text-white'
+                  : 'text-ink/60 hover:bg-positive/20 hover:text-ink',
+              )}
+              onClick={() => onViewChange?.(view)}
+            >
+              {view}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-border text-sm text-ink transition hover:border-positive hover:text-positive"
+          onClick={onToggleInfo}
+          aria-label="정보 패널 열기"
+        >
+          i
+        </button>
+        <button
+          type="button"
+          className="rounded-md border border-border px-3 py-1 text-sm text-ink transition hover:border-warning hover:text-warning"
+          onClick={onLogout}
+        >
+          로그아웃
+        </button>
+      </div>
+    </header>
+  );
+};
+
+export default TopBar;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,100 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { configureClient, ReauthPayload } from '../api/client';
+import { clearToken as clearStoredToken, getStoredToken, storeToken } from '../utils/storage';
+
+interface AuthContextValue {
+  token: string;
+  initializing: boolean;
+  setToken: (value: string) => void;
+  logout: () => void;
+  reauthInfo: ReauthPayload | null;
+  dismissReauth: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export const AuthProvider = ({ children }: AuthProviderProps) => {
+  const [token, setTokenState] = useState('');
+  const [initializing, setInitializing] = useState(true);
+  const [reauthInfo, setReauthInfo] = useState<ReauthPayload | null>(null);
+  const tokenRef = useRef(token);
+
+  useEffect(() => {
+    tokenRef.current = token;
+  }, [token]);
+
+  useEffect(() => {
+    const stored = getStoredToken();
+    if (stored) {
+      setTokenState(stored);
+    }
+    setInitializing(false);
+  }, []);
+
+  const persistToken = useCallback((value: string) => {
+    if (value) {
+      storeToken(value);
+    } else {
+      clearStoredToken();
+    }
+  }, []);
+
+  const setToken = useCallback(
+    (value: string) => {
+      setTokenState(value);
+      persistToken(value);
+    },
+    [persistToken],
+  );
+
+  const logout = useCallback(() => {
+    setToken('');
+    setReauthInfo(null);
+    clearStoredToken();
+    window.location.replace('/login');
+  }, [setToken]);
+
+  const dismissReauth = useCallback(() => {
+    setReauthInfo(null);
+  }, []);
+
+  useEffect(() => {
+    configureClient({
+      getToken: () => tokenRef.current,
+      onUnauthorized: () => {
+        logout();
+      },
+      onReauthRequired: (payload) => {
+        setReauthInfo(payload);
+      },
+    });
+  }, [logout]);
+
+  const value = useMemo(
+    () => ({ token, initializing, setToken, logout, reauthInfo, dismissReauth }),
+    [token, initializing, setToken, logout, reauthInfo, dismissReauth],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('AuthContext가 설정되지 않았습니다.');
+  }
+  return context;
+};

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,5 @@
+import { useAuthContext } from '../context/AuthContext';
+
+export const useAuth = () => {
+  return useAuthContext();
+};

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -16,6 +16,8 @@ export const useLayout = () => {
         onToday: config.onToday,
         viewType: config.viewType,
         onViewChange: config.onViewChange,
+        onRefresh: config.onRefresh,
+        isRefreshing: config.isRefreshing,
       });
     },
     [context],

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -1,0 +1,32 @@
+import { useCallback, useContext } from 'react';
+import { LayoutConfigContext, HeaderConfig } from '../components/Layout/Layout';
+
+export const useLayout = () => {
+  const context = useContext(LayoutConfigContext);
+  if (!context) {
+    throw new Error('Layout 컨텍스트를 찾을 수 없습니다.');
+  }
+
+  const setHeader = useCallback(
+    (config: HeaderConfig) => {
+      context.setHeaderConfig({
+        periodLabel: config.periodLabel,
+        onPrev: config.onPrev,
+        onNext: config.onNext,
+        onToday: config.onToday,
+        viewType: config.viewType,
+        onViewChange: config.onViewChange,
+      });
+    },
+    [context],
+  );
+
+  const updateHeader = useCallback(
+    (config: Partial<HeaderConfig>) => {
+      context.setHeaderConfig(config);
+    },
+    [context],
+  );
+
+  return { setHeader, updateHeader };
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import { AuthProvider } from './context/AuthContext';
+import router from './router';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+const AuthCallback = () => {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const { setToken } = useAuth();
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const accessToken = params.get('access_token');
+    if (!accessToken) {
+      setError('토큰이 존재하지 않습니다. 다시 로그인해주세요.');
+      return;
+    }
+
+    // 데모 목적상 localStorage에 저장합니다. 운영 환경에서는 httpOnly 쿠키 사용을 권장합니다.
+    setToken(accessToken);
+    navigate('/home/weekly', { replace: true });
+  }, [navigate, params, setToken]);
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-ivory text-ink">
+        <div className="rounded-xl bg-white/80 p-8 text-center shadow-lg">
+          <h2 className="text-lg font-semibold">인증 오류</h2>
+          <p className="mt-2 text-sm text-ink/60">{error}</p>
+          <button
+            type="button"
+            className="mt-4 rounded-md border border-border px-4 py-2 text-sm text-ink transition hover:border-positive hover:text-positive"
+            onClick={() => navigate('/login', { replace: true })}
+          >
+            로그인 페이지로 이동
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-ivory text-ink">
+      <div className="rounded-xl bg-white/80 px-6 py-4 text-sm shadow-lg">
+        Google 인증 정보를 확인 중입니다...
+      </div>
+    </div>
+  );
+};
+
+export default AuthCallback;

--- a/frontend/src/pages/HomeMonthly.tsx
+++ b/frontend/src/pages/HomeMonthly.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchAllCalendarEvents } from '../api/calendar';
 import MonthlyGrid from '../components/Calendar/MonthlyGrid';
@@ -15,11 +15,14 @@ import { CalendarEvent } from '../types';
 
 const HomeMonthly = () => {
   const navigate = useNavigate();
-  const { setHeader } = useLayout();
+  const { setHeader, updateHeader } = useLayout();
   const [currentDate, setCurrentDate] = useState(() => getStartOfMonth(new Date()));
   const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const isLoadingRef = useRef(false);
+  const isInitialLoad = useRef(true);
 
   const range = useMemo(() => {
     const start = getStartOfMonth(currentDate);
@@ -33,17 +36,35 @@ const HomeMonthly = () => {
   }, [currentDate]);
 
   const loadEvents = useCallback(async () => {
-    try {
+    if (isLoadingRef.current) {
+      return;
+    }
+
+    const initial = isInitialLoad.current;
+    isLoadingRef.current = true;
+    if (initial) {
       setLoading(true);
-      setError('');
+    } else {
+      setRefreshing(true);
+    }
+    setError('');
+    updateHeader({ isRefreshing: true });
+
+    try {
       const data = await fetchAllCalendarEvents({ timeMin: range.isoStart, timeMax: range.isoEnd });
       setEvents(data);
     } catch (err) {
       setError('일정을 불러오는 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
-      setLoading(false);
-    }
-  }, [range]);
+      if (initial) {
+        setLoading(false);
+        isInitialLoad.current = false;
+      }
+      setRefreshing(false);
+      updateHeader({ isRefreshing: false });
+      isLoadingRef.current = false;
+        }
+  }, [range, updateHeader]);
 
   const handlePrev = useCallback(() => {
     setCurrentDate((prev) => subMonth(prev));
@@ -74,16 +95,48 @@ const HomeMonthly = () => {
       onToday: handleToday,
       viewType: 'monthly',
       onViewChange: handleViewChange,
+      onRefresh: loadEvents,
+      isRefreshing: refreshing,
     });
-  }, [currentDate, handleNext, handlePrev, handleToday, handleViewChange, setHeader]);
-
+  }, [
+    currentDate,
+    handleNext,
+    handlePrev,
+    handleToday,
+    handleViewChange,
+    loadEvents,
+    refreshing,
+    setHeader,
+  ]);
   useEffect(() => {
     loadEvents();
+  }, [loadEvents]);
+
+  useEffect(() => {
+    const handleFocus = () => {
+      void loadEvents();
+    };
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        void loadEvents();
+      }
+    };
+
+    window.addEventListener('focus', handleFocus);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, [loadEvents]);
 
   return (
     <div className="flex h-full flex-col gap-4">
       {loading && <div className="rounded-md bg-white/70 px-4 py-2 text-sm text-ink/60">일정을 불러오는 중...</div>}
+      {refreshing && !loading && !error && (
+        <div className="rounded-md bg-positive/10 px-4 py-2 text-xs text-positive">최신 일정으로 동기화하는 중입니다...</div>
+      )} 
       {error && <div className="rounded-md bg-warning/30 px-4 py-2 text-sm text-ink">{error}</div>}
       {!loading && events.length === 0 && !error && (
         <div className="rounded-md border border-dashed border-border px-4 py-6 text-center text-sm text-ink/60">

--- a/frontend/src/pages/HomeMonthly.tsx
+++ b/frontend/src/pages/HomeMonthly.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchAllCalendarEvents } from '../api/calendar';
+import MonthlyGrid from '../components/Calendar/MonthlyGrid';
+import { useLayout } from '../hooks/useLayout';
+import {
+  addMonth,
+  formatISODateTime,
+  getEndOfMonth,
+  getMonthLabel,
+  getStartOfMonth,
+  subMonth,
+} from '../utils/dates';
+import { CalendarEvent } from '../types';
+
+const HomeMonthly = () => {
+  const navigate = useNavigate();
+  const { setHeader } = useLayout();
+  const [currentDate, setCurrentDate] = useState(() => getStartOfMonth(new Date()));
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const range = useMemo(() => {
+    const start = getStartOfMonth(currentDate);
+    const end = getEndOfMonth(currentDate);
+    return {
+      start,
+      end,
+      isoStart: formatISODateTime(start),
+      isoEnd: formatISODateTime(end),
+    };
+  }, [currentDate]);
+
+  const loadEvents = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError('');
+      const data = await fetchAllCalendarEvents({ timeMin: range.isoStart, timeMax: range.isoEnd });
+      setEvents(data);
+    } catch (err) {
+      setError('일정을 불러오는 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setLoading(false);
+    }
+  }, [range]);
+
+  const handlePrev = useCallback(() => {
+    setCurrentDate((prev) => subMonth(prev));
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setCurrentDate((prev) => addMonth(prev));
+  }, []);
+
+  const handleToday = useCallback(() => {
+    setCurrentDate(getStartOfMonth(new Date()));
+  }, []);
+
+  const handleViewChange = useCallback(
+    (view: 'weekly' | 'monthly') => {
+      if (view === 'weekly') {
+        navigate('/home/weekly');
+      }
+    },
+    [navigate],
+  );
+
+  useEffect(() => {
+    setHeader({
+      periodLabel: getMonthLabel(currentDate),
+      onPrev: handlePrev,
+      onNext: handleNext,
+      onToday: handleToday,
+      viewType: 'monthly',
+      onViewChange: handleViewChange,
+    });
+  }, [currentDate, handleNext, handlePrev, handleToday, handleViewChange, setHeader]);
+
+  useEffect(() => {
+    loadEvents();
+  }, [loadEvents]);
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      {loading && <div className="rounded-md bg-white/70 px-4 py-2 text-sm text-ink/60">일정을 불러오는 중...</div>}
+      {error && <div className="rounded-md bg-warning/30 px-4 py-2 text-sm text-ink">{error}</div>}
+      {!loading && events.length === 0 && !error && (
+        <div className="rounded-md border border-dashed border-border px-4 py-6 text-center text-sm text-ink/60">
+          이번 달 일정이 없습니다. Google 캘린더에서 일정을 추가해보세요.
+        </div>
+      )}
+      <div className="flex-1 overflow-hidden rounded-xl border border-border/80 bg-white/60 shadow-inner">
+        <MonthlyGrid events={events} current={range.start} />
+      </div>
+    </div>
+  );
+};
+
+export default HomeMonthly;

--- a/frontend/src/pages/HomeWeekly.tsx
+++ b/frontend/src/pages/HomeWeekly.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchAllCalendarEvents } from '../api/calendar';
+import WeeklyGrid from '../components/Calendar/WeeklyGrid';
+import { useLayout } from '../hooks/useLayout';
+import {
+  addWeek,
+  formatISODateTime,
+  getEndOfWeek,
+  getStartOfWeek,
+  getWeekRangeLabel,
+  subWeek,
+} from '../utils/dates';
+import { CalendarEvent } from '../types';
+
+const HomeWeekly = () => {
+  const navigate = useNavigate();
+  const { setHeader } = useLayout();
+  const [currentDate, setCurrentDate] = useState(() => getStartOfWeek(new Date()));
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const timeRange = useMemo(() => {
+    const start = getStartOfWeek(currentDate);
+    const end = getEndOfWeek(currentDate);
+    return {
+      start,
+      end,
+      isoStart: formatISODateTime(start),
+      isoEnd: formatISODateTime(end),
+    };
+  }, [currentDate]);
+
+  const loadEvents = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError('');
+      const data = await fetchAllCalendarEvents({ timeMin: timeRange.isoStart, timeMax: timeRange.isoEnd });
+      setEvents(data);
+    } catch (err) {
+      setError('일정을 불러오는 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setLoading(false);
+    }
+  }, [timeRange]);
+
+  const handlePrev = useCallback(() => {
+    setCurrentDate((prev) => subWeek(prev));
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setCurrentDate((prev) => addWeek(prev));
+  }, []);
+
+  const handleToday = useCallback(() => {
+    setCurrentDate(getStartOfWeek(new Date()));
+  }, []);
+
+  const handleViewChange = useCallback(
+    (view: 'weekly' | 'monthly') => {
+      if (view === 'monthly') {
+        navigate('/home/monthly');
+      }
+    },
+    [navigate],
+  );
+
+  useEffect(() => {
+    setHeader({
+      periodLabel: getWeekRangeLabel(currentDate),
+      onPrev: handlePrev,
+      onNext: handleNext,
+      onToday: handleToday,
+      viewType: 'weekly',
+      onViewChange: handleViewChange,
+    });
+  }, [currentDate, handleNext, handlePrev, handleToday, handleViewChange, setHeader]);
+
+  useEffect(() => {
+    loadEvents();
+  }, [loadEvents]);
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      {loading && <div className="rounded-md bg-white/70 px-4 py-2 text-sm text-ink/60">일정을 불러오는 중...</div>}
+      {error && <div className="rounded-md bg-warning/30 px-4 py-2 text-sm text-ink">{error}</div>}
+      {!loading && events.length === 0 && !error && (
+        <div className="rounded-md border border-dashed border-border px-4 py-6 text-center text-sm text-ink/60">
+          이번 주 일정이 없습니다. Google 캘린더에서 일정을 추가해보세요.
+        </div>
+      )}
+      <div className="flex-1 overflow-hidden rounded-xl border border-border/80 bg-white/60 shadow-inner">
+        <WeeklyGrid events={events} start={timeRange.start} />
+      </div>
+    </div>
+  );
+};
+
+export default HomeWeekly;

--- a/frontend/src/pages/HomeWeekly.tsx
+++ b/frontend/src/pages/HomeWeekly.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchAllCalendarEvents } from '../api/calendar';
 import WeeklyGrid from '../components/Calendar/WeeklyGrid';
@@ -15,11 +15,14 @@ import { CalendarEvent } from '../types';
 
 const HomeWeekly = () => {
   const navigate = useNavigate();
-  const { setHeader } = useLayout();
+  const { setHeader, updateHeader } = useLayout();
   const [currentDate, setCurrentDate] = useState(() => getStartOfWeek(new Date()));
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
+  const isLoadingRef = useRef(false);
+  const isInitialLoad = useRef(true);
 
   const timeRange = useMemo(() => {
     const start = getStartOfWeek(currentDate);
@@ -33,17 +36,34 @@ const HomeWeekly = () => {
   }, [currentDate]);
 
   const loadEvents = useCallback(async () => {
-    try {
+    if (isLoadingRef.current) {
+      return;
+    }
+
+    const initial = isInitialLoad.current;
+    isLoadingRef.current = true;
+    if (initial) {
       setLoading(true);
-      setError('');
-      const data = await fetchAllCalendarEvents({ timeMin: timeRange.isoStart, timeMax: timeRange.isoEnd });
+    } else {
+      setRefreshing(true);
+    }
+    setError('');
+    updateHeader({ isRefreshing: true });
+
+    try {      const data = await fetchAllCalendarEvents({ timeMin: timeRange.isoStart, timeMax: timeRange.isoEnd });
       setEvents(data);
     } catch (err) {
       setError('일정을 불러오는 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
-      setLoading(false);
+      if (initial) {
+        setLoading(false);
+        isInitialLoad.current = false;
+      }
+      setRefreshing(false);
+      updateHeader({ isRefreshing: false });
+      isLoadingRef.current = false;
     }
-  }, [timeRange]);
+  }, [timeRange, updateHeader]);
 
   const handlePrev = useCallback(() => {
     setCurrentDate((prev) => subWeek(prev));
@@ -74,16 +94,48 @@ const HomeWeekly = () => {
       onToday: handleToday,
       viewType: 'weekly',
       onViewChange: handleViewChange,
+      onRefresh: loadEvents,
+      isRefreshing: refreshing,
     });
-  }, [currentDate, handleNext, handlePrev, handleToday, handleViewChange, setHeader]);
-
+  }, [
+    currentDate,
+    handleNext,
+    handlePrev,
+    handleToday,
+    handleViewChange,
+    loadEvents,
+    refreshing,
+    setHeader,
+  ]);
   useEffect(() => {
     loadEvents();
+  }, [loadEvents]);
+
+  useEffect(() => {
+    const handleFocus = () => {
+      void loadEvents();
+    };
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        void loadEvents();
+      }
+    };
+
+    window.addEventListener('focus', handleFocus);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, [loadEvents]);
 
   return (
     <div className="flex h-full flex-col gap-4">
       {loading && <div className="rounded-md bg-white/70 px-4 py-2 text-sm text-ink/60">일정을 불러오는 중...</div>}
+      {refreshing && !loading && !error && (
+        <div className="rounded-md bg-positive/10 px-4 py-2 text-xs text-positive">최신 일정으로 동기화하는 중입니다...</div>
+      )}      
       {error && <div className="rounded-md bg-warning/30 px-4 py-2 text-sm text-ink">{error}</div>}
       {!loading && events.length === 0 && !error && (
         <div className="rounded-md border border-dashed border-border px-4 py-6 text-center text-sm text-ink/60">

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { requestGoogleLogin } from '../api/auth';
+
+const Login = () => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const startLogin = async (force: boolean) => {
+    try {
+      setLoading(true);
+      setError('');
+      const { auth_url: authUrl } = await requestGoogleLogin(force);
+      window.location.assign(authUrl);
+    } catch (err) {
+      setError('로그인 URL을 가져오지 못했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-ivory">
+      <div className="w-full max-w-md rounded-2xl bg-white/80 p-8 shadow-xl">
+        <div className="flex h-12 w-12 items-center justify-center rounded-lg border border-border">
+          <div className="grid grid-cols-3 gap-0.5">
+            {Array.from({ length: 9 }).map((_, index) => (
+              <span key={index} className="h-1.5 w-1.5 rounded-full bg-positive" />
+            ))}
+          </div>
+        </div>
+        <h1 className="mt-6 text-2xl font-bold text-ink">할 수 있다. 일단 트라이.</h1>
+        <p className="mt-2 text-sm text-ink/60">Yakssok 캘린더에 연결하여 스케줄을 확인하세요.</p>
+        <div className="mt-6 space-y-3">
+          <button
+            type="button"
+            className="w-full rounded-md bg-positive px-4 py-3 text-sm font-semibold text-white transition hover:bg-positive/90 disabled:opacity-70"
+            onClick={() => startLogin(false)}
+            disabled={loading}
+          >
+            {loading ? '연결 중...' : 'Google로 로그인'}
+          </button>
+          <button
+            type="button"
+            className="w-full rounded-md border border-border px-4 py-3 text-sm font-semibold text-ink transition hover:border-positive hover:text-positive disabled:opacity-70"
+            onClick={() => startLogin(true)}
+            disabled={loading}
+          >
+            권한 재인증(강제)
+          </button>
+        </div>
+        {error && <div className="mt-4 text-sm text-warning">{error}</div>}
+        {loading && (
+          <div className="mt-4 flex items-center gap-2 text-sm text-ink/60">
+            <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-positive border-t-transparent" />
+            <span>Google OAuth 페이지를 여는 중입니다...</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,51 @@
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+import App from './App';
+import Login from './pages/Login';
+import AuthCallback from './pages/AuthCallback';
+import HomeWeekly from './pages/HomeWeekly';
+import HomeMonthly from './pages/HomeMonthly';
+import ProtectedRoute from './routes/ProtectedRoute';
+import RootRedirect from './routes/RootRedirect';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <RootRedirect />,
+  },
+  {
+    path: '/login',
+    element: <Login />,
+  },
+  {
+    path: '/auth/callback',
+    element: <AuthCallback />,
+  },
+  {
+    path: '/home',
+    element: (
+      <ProtectedRoute>
+        <App />
+      </ProtectedRoute>
+    ),
+    children: [
+      {
+        index: true,
+        element: <Navigate to="/home/weekly" replace />,
+      },
+      {
+        path: 'weekly',
+        element: <HomeWeekly />,
+      },
+      {
+        path: 'monthly',
+        element: <HomeMonthly />,
+      },
+    ],
+  },
+  {
+    path: '*',
+    element: <Navigate to="/" replace />,
+  },
+]);
+
+export default router;

--- a/frontend/src/routes/ProtectedRoute.tsx
+++ b/frontend/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,27 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+interface ProtectedRouteProps {
+  children: React.ReactElement;
+}
+
+const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+  const { token, initializing } = useAuth();
+  const location = useLocation();
+
+  if (initializing) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-ivory text-ink">
+        <div className="text-sm text-ink/60">초기화 중...</div>
+      </div>
+    );
+  }
+
+  if (!token) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/routes/RootRedirect.tsx
+++ b/frontend/src/routes/RootRedirect.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getStoredToken } from '../utils/storage';
+
+const RootRedirect = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = getStoredToken();
+    if (token) {
+      navigate('/home/weekly', { replace: true });
+    } else {
+      navigate('/login', { replace: true });
+    }
+  }, [navigate]);
+
+  return null;
+};
+
+export default RootRedirect;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,28 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color: #2B2B2B;
+  background-color: #F7F8F2;
+  font-family: 'Pretendard', 'Noto Sans KR', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+a {
+  color: inherit;
+}
+
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid #9FD6AF;
+  outline-offset: 2px;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.15);
+  border-radius: 9999px;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,12 @@
+export interface CalendarEvent {
+  id: string;
+  summary: string;
+  start: string;
+  end: string;
+  location?: string;
+}
+
+export interface CalendarEventResponse {
+  events: CalendarEvent[];
+  nextPageToken?: string;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,8 +1,14 @@
+export interface CalendarDateTime {
+  date?: string;
+  dateTime?: string;
+  timeZone?: string;
+}
+
 export interface CalendarEvent {
   id: string;
   summary: string;
-  start: string;
-  end: string;
+  start: string | CalendarDateTime;
+  end: string | CalendarDateTime;
   location?: string;
 }
 

--- a/frontend/src/utils/colors.ts
+++ b/frontend/src/utils/colors.ts
@@ -1,0 +1,17 @@
+const keywordColorMap: Record<string, string> = {
+  운동: 'bg-positive',
+  스터디: 'bg-positive',
+  학습: 'bg-positive',
+  회의: 'bg-neutral',
+  마감: 'bg-warning',
+  경고: 'bg-warning',
+  중요: 'bg-warning',
+};
+
+export const getEventColorClass = (summary: string) => {
+  const matched = Object.entries(keywordColorMap).find(([keyword]) => summary.includes(keyword));
+  if (matched) {
+    return matched[1];
+  }
+  return 'bg-neutral';
+};

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -58,3 +58,12 @@ export const getMonthMatrix = (date: Date) => {
 export const isDateInCurrentMonth = (date: Date, current: Date) => isSameMonth(date, current);
 
 export const getDaysCountOfMonth = (date: Date) => getDaysInMonth(date);
+
+export const toValidDate = (value: string | Date | null | undefined) => {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -1,0 +1,60 @@
+import {
+  addMonths,
+  addWeeks,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  formatISO,
+  getDaysInMonth,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+  subWeeks,
+} from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+export const getStartOfWeek = (date: Date) => startOfWeek(date, { weekStartsOn: 1 });
+export const getEndOfWeek = (date: Date) => endOfWeek(date, { weekStartsOn: 1 });
+
+export const getStartOfMonth = (date: Date) => startOfMonth(date);
+export const getEndOfMonth = (date: Date) => endOfMonth(date);
+
+export const getWeekRangeLabel = (date: Date) => {
+  const start = getStartOfWeek(date);
+  const end = getEndOfWeek(date);
+  return `${format(start, 'yyyy년 M월 d일', { locale: ko })} – ${format(end, 'M월 d일', { locale: ko })}`;
+};
+
+export const getMonthLabel = (date: Date) => format(date, 'yyyy년 M월', { locale: ko });
+
+export const getWeekDays = (date: Date) => {
+  const start = getStartOfWeek(date);
+  const end = getEndOfWeek(date);
+  return eachDayOfInterval({ start, end });
+};
+
+export const addWeek = (date: Date) => addWeeks(date, 1);
+export const subWeek = (date: Date) => subWeeks(date, 1);
+export const addMonth = (date: Date) => addMonths(date, 1);
+export const subMonth = (date: Date) => subMonths(date, 1);
+
+export const formatISODateTime = (date: Date) => formatISO(date);
+
+export const getMonthMatrix = (date: Date) => {
+  const start = getStartOfWeek(startOfMonth(date));
+  const end = getEndOfWeek(endOfMonth(date));
+  const days = eachDayOfInterval({ start, end });
+  const weeks: Date[][] = [];
+
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
+
+  return weeks;
+};
+
+export const isDateInCurrentMonth = (date: Date, current: Date) => isSameMonth(date, current);
+
+export const getDaysCountOfMonth = (date: Date) => getDaysInMonth(date);

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -14,6 +14,7 @@ import {
   subWeeks,
 } from 'date-fns';
 import { ko } from 'date-fns/locale';
+import { CalendarDateTime } from '../types';
 
 export const getStartOfWeek = (date: Date) => startOfWeek(date, { weekStartsOn: 1 });
 export const getEndOfWeek = (date: Date) => endOfWeek(date, { weekStartsOn: 1 });
@@ -59,11 +60,26 @@ export const isDateInCurrentMonth = (date: Date, current: Date) => isSameMonth(d
 
 export const getDaysCountOfMonth = (date: Date) => getDaysInMonth(date);
 
-export const toValidDate = (value: string | Date | null | undefined) => {
-  if (!value) {
+type DateLike = string | Date | CalendarDateTime | null | undefined;
+
+export const toValidDate = (value: DateLike) => {  if (!value) {
     return null;
   }
 
-  const date = value instanceof Date ? value : new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const dateString = value.dateTime ?? value.date;
+  if (!dateString) {
+    return null;
+  }
+
+  const parsed = new Date(dateString);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 };

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,0 +1,19 @@
+const TOKEN_KEY = 'access_token';
+
+export const getStoredToken = () => {
+  return localStorage.getItem(TOKEN_KEY) ?? '';
+};
+
+export const storeToken = (token: string) => {
+  localStorage.setItem(TOKEN_KEY, token);
+};
+
+export const clearToken = () => {
+  localStorage.removeItem(TOKEN_KEY);
+};
+
+export default {
+  getStoredToken,
+  storeToken,
+  clearToken,
+};

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,17 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        ivory: '#F7F8F2',
+        ink: '#2B2B2B',
+        border: '#E5E7EB',
+        positive: '#9FD6AF',
+        warning: '#F3B39D',
+        neutral: '#D4D4D8',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    define: {
+      __APP_ENV__: env.APP_ENV,
+    },
+    server: {
+      host: '0.0.0.0',
+      port: 5173,
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript frontend with Tailwind CSS styling
- implement OAuth login callback handling, auth context, and Axios interceptors for calendar APIs
- add weekly and monthly calendar views with reauthentication banner and shared layout components

## Testing
- `npm install` *(fails: 403 Forbidden when downloading packages from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d6156538c08332b8723d51c226cb86